### PR TITLE
PR : Remove the concept of number of HP and Total volumetric flow in the HeatPump class

### DIFF
--- a/pygld/heatpumps/heatpump.py
+++ b/pygld/heatpumps/heatpump.py
@@ -81,16 +81,18 @@ class HeatPump(object):
                 applied to the heatpump.
         fluid : heat carrier fluid type
         fr    : antifreeze volumetric fraction
-        Vhp   : fluid carrier volumetric flowrate in the heatpump in L/s
+        Vf    : fluid carrier volumetric flowrate in the heatpump in L/s
         Tg    : undisturbed ground temperature in ºC
         """
 
         self._hpdb = load_heatpump_database()
 
         self.qbat = {'cooling': 16.5, 'heating': 14.5}
+        self.Tg = 12
+
+        self.Vf = {'cooling': 0.05 * 16.5, 'heating': 0.05 * 14.5}
         self.fluid = 'water'
         self.fr = 0
-        self.Tg = 12
 
     @property
     def hpdata(self):
@@ -168,7 +170,7 @@ class HeatPump(object):
 
         # Calculate outflow fluid temperature :
 
-        ToutHP = self.TinHP[mode] + qgnd/(self.Vhp[mode]*rhof*cpf) * 10**6
+        ToutHP = self.TinHP[mode] + qgnd/(self.Vf[mode]*rhof*cpf) * 10**6
 
         return ToutHP
 
@@ -229,9 +231,9 @@ class HeatPump(object):
         specified mode of operation (cooling of heating).
         """
         if mode == 'cooling':
-            return self.interp('COPc', self.TinHP[mode], self.Vhp[mode])
+            return self.interp('COPc', self.TinHP[mode], self.Vf[mode])
         elif mode == 'heating':
-            return self.interp('COPh', self.TinHP[mode], self.Vhp[mode])
+            return self.interp('COPh', self.TinHP[mode], self.Vf[mode])
 
     def get_CAP(self, mode):
         """
@@ -239,9 +241,9 @@ class HeatPump(object):
         mode of operation (cooling of heating).
         """
         if mode == 'cooling':
-            return self.interp('CAPc', self.TinHP[mode], self.Vhp[mode])
+            return self.interp('CAPc', self.TinHP[mode], self.Vf[mode])
         elif mode == 'heating':
-            return self.interp('CAPh', self.TinHP[mode], self.Vhp[mode])
+            return self.interp('CAPh', self.TinHP[mode], self.Vf[mode])
 
     # ---- Utility methods
 

--- a/pygld/heatpumps/heatpump.py
+++ b/pygld/heatpumps/heatpump.py
@@ -64,19 +64,7 @@ class HeatPump(object):
     def __init__(self):
         """
         TinHP  : temperature of the fluid entering the HP in ºC.
-        Nhp    : number of heat pump
         hpname : name of the heat pump
-        """
-
-        self.__initAttr__()
-
-        self.TinHP = {'cooling': 28, 'heating': 0}
-        self.set_hpname(0)
-
-    def __initAttr__(self):
-        """
-        Initialize the attributes that are not to be linked with the UI
-
         qbat  : building thermal load in kW (+ for cooling, - for heating)
                 applied to the heatpump.
         fluid : heat carrier fluid type
@@ -84,13 +72,14 @@ class HeatPump(object):
         Vf    : fluid carrier volumetric flowrate in the heatpump in L/s
         Tg    : undisturbed ground temperature in ºC
         """
-
         self._hpdb = load_heatpump_database()
+        self.set_hpname(0)
 
+        self.TinHP = {'cooling': 28, 'heating': 0}
         self.qbat = {'cooling': 16.5, 'heating': 14.5}
         self.Tg = 12
-
-        self.Vf = {'cooling': 0.05 * 16.5, 'heating': 0.05 * 14.5}
+        self.Vf = {'cooling': np.mean(self.get_flowRange()),
+                   'heating': np.mean(self.get_flowRange())}
         self.fluid = 'water'
         self.fr = 0
 


### PR DESCRIPTION
While writing the documentation for the `heatpumps` module, I realized that the concept of "number of heat pumps" and "Total volumetric flow" was confusing to use with the `HeatPump` class.

An instance of `HeatPump` should correspond to one physical heatpump. For a system of heatpumps, one should create multiple instances of `HeatPump`.

Therefore:
- all references to the `Nhp` and `Vftot` attributes were removed in the class
- `qbat` have been redefined:  building thermal load in kW (+ for cooling, - for heating) applied to the heatpump.
- `Vhp` have been renamed `Vf` and redefined:  fluid carrier volumetric flowrate in the heatpump in L/s