### PR TITLE
PR: Vectorization of the "heatpump" module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ install:
   - pip install pytest-cov
   - pip install pytest-ordering
   - pip install coveralls
+  - pip install codecov
   - pip install matplotlib
   - pip install scipy
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,4 @@ script:
 
 after_success:
   - coveralls
+  - codecov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,28 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+codecov:
+  branch: master
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch: no
+    changes: no
+    
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+  
+comment: false

--- a/pygld/fluidproperties.py
+++ b/pygld/fluidproperties.py
@@ -12,6 +12,8 @@ import numpy as np
 from scipy import interpolate
 import os
 
+FLUIDS = ['prop_glycol', 'ethyl_glycol', 'water']
+
 
 class HeatCarrierFluid(object):
     """
@@ -84,8 +86,7 @@ class HeatCarrierFluid(object):
             self.__fluid = 'water'
             filename = 'proptables_purewater.npy'
         else:
-            raise ValueError('Supported fluid value are',
-                             ['water', 'prop_glycol', 'ethyl_glycol'])
+            raise ValueError('Supported fluid value are', FLUIDS)
 
         dirname = os.path.dirname(os.path.realpath(__file__))
         pathname = os.path.join(dirname, 'tables', filename)

--- a/pygld/heatpumps/heatpump.py
+++ b/pygld/heatpumps/heatpump.py
@@ -242,7 +242,7 @@ class HeatPump(object):
 
             # Calcul the ground loads.
 
-            self.calcul_COP()
+            self._calcul_COP()
             qgnd = self._qbat * (self._COP - np.sign(self._qbat)) / self._COP
 
             # qbat is - for cooling and + for heating

--- a/pygld/heatpumps/heatpump.py
+++ b/pygld/heatpumps/heatpump.py
@@ -8,7 +8,7 @@
 
 # ---- Standard imports
 
-from collections.abc import Mapping
+import copy
 
 # ---- Third party imports
 
@@ -64,66 +64,45 @@ corrtbl_afreeze[tbl_fluid2['name']] = tbl_fluid2
 class HeatPump(object):
 
     def __init__(self):
-        """
-        TinHP  : temperature of the fluid entering the HP in ºC.
-        model : model of the heat pump
-        qbat  : building thermal load in kW (+ for cooling, - for heating)
-                applied to the heatpump.
-        fluid : heat carrier fluid type
-        fr    : antifreeze volumetric fraction
-        Vf    : fluid carrier volumetric flowrate in the heatpump in L/s
-        """
         self._hpdb = load_heatpump_database()
         self.set_model(0)
 
         # Independent properties :
 
-        self._TinHP = IndependentProp(self, cooling=28, heating=0)
-        self.qbat = IndependentProp(self, cooling=16.5, heating=14.5)
+        self._TinHP = np.array([28, 0])
+        self._qbat = np.array([-16.5, 14.5])
+        self._Vf = np.array([0.94635295, 0.94635295])
+        self._fr = 0
+        self._hcfluid = HeatCarrierFluid('water', self._TinHP, self._fr)
 
-        self.Vf = IndependentProp(self, cooling=0.94635295, heating=0.94635295)
-        self.fluid = 'water'
-        self.fr = 0
+        # Setup the update dependent properties flag :
 
-        # Dependent properties :
-
-        self._Tm = DependentProp(self)
-        self._ToutHP = DependentProp(self)
-        self._COP = DependentProp(self)
-        self._CAP = DependentProp(self)
-
-        self._dependent_props = [self._Tm, self._ToutHP, self._COP, self._CAP]
-        self._need_update = {id(p): True for p in self._dependent_props}
+        self._dependent_props = ['Tm', 'ToutHP', 'COP', 'CAP']
+        self._varstate_has_changed()
 
     def __str__(self):
-        str_ = "model: %s\n" % self.model
-        str_ += "-" * 25 + "\n"
-        str_ += "qbat (%s): %0.2f kW\n" % ('heating', self.qbat.h)
-        str_ += "qbat (%s): %0.2f kW\n" % ('cooling', self.qbat.c)
-        str_ += "-" * 25 + "\n"
-        str_ += 'Vf (%s): %0.2f L/s\n' % ('heating', self.Vf.h)
-        str_ += 'Vf (%s): %0.2f L/s\n' % ('cooling', self.Vf.c)
-        str_ += 'fluid: %s\n' % self.fluid
-        str_ += 'fr   : %s\n' % self.fr
-        for mode in ['heating', 'cooling']:
-            str_ += "-" * 25 + "\n"
-            str_ += 'TinHP  (%s): %0.2f \u00B0C\n' % (mode, self.TinHP[mode])
-            str_ += 'ToutHP (%s): %0.2f \u00B0C\n' % (mode, self.ToutHP[mode])
-            str_ += 'Tm     (%s): %0.2f \u00B0C\n' % (mode, self.Tm[mode])
-            str_ += 'COP    (%s): %0.2f\n' % (mode, self.COP[mode])
-            str_ += 'CAP    (%s): %0.2f kW\n' % (mode, self.CAP[mode])
+        str_ = "model: %s" % self.model
+        str_ += '\nfluid: %s' % self.fluid
+        str_ += '\nfr   : %d' % self.fr
+        str_ += '\nVf (L/s): ' + self.Vf.__str__()
+        str_ += "\nqbat (kW): " + self.qbat.__str__()
+        str_ += '\nTinHP (\u00B0C): ' + self.TinHP.__str__()
+        str_ += '\nToutHP (\u00B0C): ' + self.ToutHP.__str__()
+        str_ += '\nTm (\u00B0C): ' + self.Tm.__str__()
+        str_ += '\nCOP : ' + self.COP.__str__()
+        str_ += '\nCAP (kW): ' + self.CAP.__str__()
         return str_
 
     # ---- Model and data
 
     @property
     def hpdata(self):
-        """Return the performance data table of the heat pump."""
+        """Return the performance data table of the heatpump."""
         return self._hpdb[self.model]
 
     @property
     def model(self):
-        """Return the name of the current heat pump."""
+        """Return the name of the current heatpump."""
         return self._model
 
     def set_model(self, value):
@@ -145,101 +124,187 @@ class HeatPump(object):
     # ---- Independent properties
 
     @property
+    def fluid(self):
+        """Type of heat carrier fluid."""
+        return copy.copy(self._hcfluid.fluid)
+
+    @fluid.setter
+    def fluid(self, value):
+        self._hcfluid.fluid = value
+        self._varstate_has_changed()
+
+    @property
+    def fr(self):
+        """Volumetric fraction of antifreeze of the heat carrier fluid."""
+        return copy.copy(self._hcfluid.fr)
+
+    @fr.setter
+    def fr(self, value):
+        self._hcfluid.fr = value
+        self._varstate_has_changed()
+
+    @property
     def TinHP(self):
         """
-        Temperature of the water entering the heat pump (EWT) in ºC.
+        Temperature of the water entering the heatpump (EWT) in ºC.
         """
-        return self._TinHP
+        return np.copy(self._TinHP)
 
     @TinHP.setter
     def TinHP(self, values):
-        """
-        Set the maximum cooling and minimum heating temperature of the water
-        entering the heat pump (EWT) in ºC from a tuple of floats, where the
-        first value is for the cooling mode and second for the heating mode.
-        """
-        self._TinHP.c = values[0]
-        self._TinHP.h = values[1]
-
-    # ---- Dependent properties
+        values = values if isinstance(values, np.ndarray) else np.array(values)
+        self._TinHP = values
+        self._hcfluid.Tref = values
+        self._varstate_has_changed()
 
     @property
-    def ToutHP(self):
+    def qbat(self):
         """
-        Temperature of the water leaving the heat pump (LWT) in ºC.
+        Part of the building thermal load applied to the heatpump in kW
+        (- for cooling, + for heating).
         """
-        if self._need_update[id(self._ToutHP)]:
-            self._ToutHP._heating = self.calcul_ToutHP_for_mode('heating')
-            self._ToutHP._cooling = self.calcul_ToutHP_for_mode('cooling')
-            self._need_update[id(self._ToutHP)] = False
-        return self._ToutHP
+        return np.copy(self._qbat)
+
+    @qbat.setter
+    def qbat(self, values):
+        values = values if isinstance(values, np.ndarray) else np.array(values)
+        self._qbat = values
+        self._varstate_has_changed()
 
     @property
-    def Tm(self):
+    def Vf(self):
         """
-        Mean temperature of the water circulating through the heat pump in ºC
+        Volumetric flowrate of the fluid carrier through the heatpump in L/s
         """
-        if self._need_update[id(self._Tm)]:
-            self._Tm._heating = (self.TinHP.h + self.ToutHP.h)/2
-            self._Tm._cooling = (self.TinHP.c + self.ToutHP.c)/2
-            self._need_update[id(self._Tm)] = False
-        return self._Tm
+        return np.copy(self._Vf)
 
-    @property
-    def COP(self):
-        """Coefficient of performance of the heatpump."""
-        if self._need_update[id(self._COP)]:
-            self._COP._heating = \
-                self.eval_fitmodel_for('COPh', self.TinHP.h, self.Vf.h)
-            self._COP._cooling = \
-                self.eval_fitmodel_for('COPc', self.TinHP.c, self.Vf.c)
-            self._need_update[id(self._COP)] = False
-        return self._COP
-
-    @property
-    def CAP(self):
-        """Capacity of the heatpump in kW."""
-        if self._need_update[id(self._CAP)]:
-            self._CAP._heating = \
-                self.eval_fitmodel_for('CAPh', self.TinHP.h, self.Vf.h)
-            self._CAP._cooling = \
-                self.eval_fitmodel_for('CAPc', self.TinHP.c, self.Vf.c)
-            self._need_update[id(self._CAP)] = False
-        return self._CAP
+    @Vf.setter
+    def Vf(self, values):
+        values = values if isinstance(values, np.ndarray) else np.array(values)
+        self._Vf = values
+        self._varstate_has_changed()
 
     def _varstate_has_changed(self):
         """
         Reset the '_need_update' flags for all the dependent variables
         when the value of an independent variable changes.
         """
-        self._need_update = {id(p): True for p in self._dependent_props}
+        self._need_update = {p: True for p in self._dependent_props}
+
+    # ---- Dependent properties
+
+    @property
+    def ToutHP(self):
+        """
+        Temperature of the water leaving the heatpump (LWT) in ºC.
+        """
+        if self._need_update['ToutHP']:
+            self._ToutHP = self.calcul_ToutHP()
+            self._need_update['ToutHP'] = False
+        return np.copy(self._ToutHP)
+
+    @property
+    def Tm(self):
+        """
+        Mean temperature of the water circulating through the heatpump in ºC
+        """
+        if self._need_update['Tm']:
+            self._Tm = self.calcul_Tm()
+            self._need_update['Tm'] = False
+        return np.copy(self._Tm)
+
+    @property
+    def COP(self):
+        """Coefficient of performance of the heatpump."""
+        if self._need_update['COP']:
+            self._COP = self.calcul_COP()
+            self._need_update['COP'] = False
+        return np.copy(self._COP)
+
+    @property
+    def CAP(self):
+        """Capacity of the heatpump in kW."""
+        if self._need_update['CAP']:
+            self._CAP = self.calcul_CAP()
+            self._need_update['CAP'] = False
+        return np.copy(self._CAP)
 
     # ---- Calculs
 
-    def calcul_ToutHP_for_mode(self, mode):
+    def calcul_Tm(self):
         """
-        Calcul the temperature of the fluid leaving the heat pump for the
-        current mode of operation (cooling or heating).
+        Calcul the average temperature of the fluid circulating through the
+        heatpump in ºC for every TinHP values.
         """
+        return (self.TinHP + self.ToutHP)/2
 
-        # Calculate fluid properties :
+    def calcul_ToutHP(self):
+        """
+        Calcul the temperature of the fluid leaving the heatpump in ºC for
+        every TinHP values.
+        """
+        TinHP, Vf, qbat = self.TinHP, self.Vf, self.qbat
+        COP = self.COP
 
-        hcfluid = HeatCarrierFluid(self.fluid, self.TinHP[mode], self.fr)
-        rhof = hcfluid.rho
-        cpf = hcfluid.cp
+        if len(TinHP) != len(Vf) != len(qbat):
+            raise ValueError("The lenght of TinHP, Vf, and qbat must match"
+                             " exactly.")
 
-        # Calculate ground load :
+        # Get the fluid properties.
 
-        if mode == 'cooling':
-            qgnd = self.qbat[mode] * (self.COP[mode] + 1) / self.COP[mode]
-        elif mode == 'heating':
-            qgnd = -self.qbat[mode] * (self.COP[mode] - 1) / self.COP[mode]
+        rhof, cpf = self._hcfluid.rho, self._hcfluid.cp
 
-        # Calculate outflow fluid temperature :
+        # Calcul the ground loads.
 
-        ToutHP = self.TinHP[mode] + qgnd/(self.Vf[mode]*rhof*cpf) * 10**6
+        qgnd = qbat * (COP - np.sign(qbat)) / COP
+
+        # qbat is - for cooling and + for heating
+        # qgnd = qbat * (COP + 1)/COP in cooling mode
+        # qgnd = qbat * (COP - 1)/COP in heating mode
+
+        # Calculate outflow fluid temperature.
+
+        ToutHP = TinHP - qgnd/(Vf*rhof*cpf) * 10**6
 
         return ToutHP
+
+    def calcul_COP(self):
+        """
+        Calcul the coefficient of performance of the heatpump for each pair
+        of TinHP and Vf values.
+        """
+        return self._calcul_cop_or_cap('COP')
+
+    def calcul_CAP(self):
+        """
+        Calcul the capacity of the heatpump in kW for each pair of TinHP and
+        Vf values.
+        """
+        return self._calcul_cop_or_cap('CAP')
+
+    def _calcul_cop_or_cap(self, varname):
+        """Calcul the CAP or COP for each pair of TinHP and Vf values."""
+        TinHP, Vf, qbat = self.TinHP, self.Vf, self.qbat
+
+        if len(TinHP) != len(Vf) != len(qbat):
+            raise ValueError("The lenght of TinHP, Vf, and qbat must match"
+                             " exactly.")
+
+        ndarray = np.empty(len(TinHP))
+
+        # Calcul values when cooling.
+
+        indx = np.where(qbat < 0)[0]
+        ndarray[indx] = self.eval_fitmodel_for(
+            varname + 'c', TinHP[indx], Vf[indx])
+
+        # Calcul values when heating.
+
+        indx = np.where(qbat >= 0)[0]
+        ndarray[indx] = self.eval_fitmodel_for(
+            varname + 'h', TinHP[indx], Vf[indx])
+
+        return ndarray
 
     def eval_fitmodel_for(self, varname, ewt, vf):
         """
@@ -315,71 +380,9 @@ class HeatPump(object):
             print("%s%d - %s" % (indent, i, model))
 
 
-class DependentProp(Mapping):
-    """A dependent property of the heatpump."""
-
-    COOLING_ATTRS = ['cooling', 'c', 0]
-    HEATING_ATTRS = ['heating', 'h', 1]
-
-    def __init__(self, parent, cooling=None, heating=None):
-        super(DependentProp, self).__init__()
-        self._parent = parent
-        self._cooling = cooling
-        self._heating = heating
-
-    def __getitem__(self, key):
-        return self.__getattr__(key)
-
-    def __getattr__(self, attr):
-        if attr in self.COOLING_ATTRS:
-            return self._cooling
-        elif attr in self.HEATING_ATTRS:
-            return self._heating
-        else:
-            try:
-                return super().__getattr__(attr)
-            except AttributeError:
-                raise AttributeError(attr)
-
-    def __setitem__(self, key, value):
-        self.__setattr__(key, value)
-
-    def __setattr__(self, attr, value):
-        if attr in self.COOLING_ATTRS + self.HEATING_ATTRS:
-            raise AttributeError('Cannot set attribute %s' % attr)
-        else:
-            super().__setattr__(attr, value)
-
-    def __iter__(self):
-        for x in [self._cooling, self._heating]:
-            yield x
-
-    def __len__(self, key):
-        return 2
-
-    def __str__(self):
-        return "{'cooling': %f, 'heating': %f}" % (self.cooling, self.heating)
-
-
-class IndependentProp(DependentProp):
-    """An independent property of the heatpump."""
-
-    def __setitem__(self, key, value):
-        self.__setattr__(key, value)
-
-    def __setattr__(self, attr, value):
-        if attr in self.COOLING_ATTRS:
-            self._cooling = value
-            self._parent._varstate_has_changed()
-        elif attr in self.HEATING_ATTRS:
-            self._heating = value
-            self._parent._varstate_has_changed()
-        else:
-            super().__setattr__(attr, value)
-
-
 if __name__ == '__main__':
     heatpump = HeatPump()
     print(heatpump)
-    heatpump.plot_heatpump_model_goodness()
-    heatpump.print_avail_heatpump_models()
+    # print(heatpump)
+    # heatpump.plot_heatpump_model_goodness()
+    # heatpump.print_avail_heatpump_models()

--- a/pygld/heatpumps/heatpump.py
+++ b/pygld/heatpumps/heatpump.py
@@ -8,8 +8,6 @@
 
 # ---- Standard imports
 
-import copy
-
 # ---- Third party imports
 
 import numpy as np
@@ -125,8 +123,15 @@ class HeatPump(object):
 
     @property
     def fluid(self):
-        """Type of heat carrier fluid."""
-        return copy.copy(self._hcfluid.fluid)
+        """Heat carrier fluid type.
+
+        Get or set the type of heat carrier fluid used in the geothermal
+        heat exchanger. The currently available fluid types are 'water',
+        'ethyl_glycol', and 'prop_glycol'.
+        The heat carrier fluid is assumed to be 'water' when
+        :attr:`~pygld.HeatPump.fr` is set to 0.
+        """
+        return self._hcfluid.fluid
 
     @fluid.setter
     def fluid(self, x):
@@ -135,8 +140,14 @@ class HeatPump(object):
 
     @property
     def fr(self):
-        """Volumetric fraction of antifreeze in the heat carrier fluid."""
-        return copy.copy(self._hcfluid.fr)
+        """Antifreeze volumetric fraction of the heat carrier fluid in m³/m³
+        (0 ≤ fr ≤ 1).
+
+        Get or set the antifreeze volumetric fraction of the heat carrier
+        fluid. The value of `fr` must be between 0 and 1 and is assumed to be
+        0 when :attr:`~pygld.HeatPump.fluid` is set to 'water'.
+        """
+        return self._hcfluid.fr
 
     @fr.setter
     def fr(self, x):
@@ -146,7 +157,7 @@ class HeatPump(object):
     @property
     def TinHP(self):
         """
-        Temperature of the water entering the heatpump in ºC.
+        Temperature of the water entering the heatpump in °C.
         """
         return np.copy(self._TinHP)
 
@@ -189,14 +200,14 @@ class HeatPump(object):
     @property
     def ToutHP(self):
         """
-        Temperature of the water leaving the heatpump in ºC.
+        Temperature of the water leaving the heatpump in °C.
         """
         return np.copy(self._calcul_ToutHP())
 
     @property
     def Tm(self):
         """
-        Mean temperature of the water circulating through the heatpump in ºC
+        Mean temperature of the water circulating through the heatpump in °C
         """
         return np.copy(self._calcul_Tm())
 

--- a/pygld/heatpumps/tests/test_heatpump.py
+++ b/pygld/heatpumps/tests/test_heatpump.py
@@ -78,10 +78,35 @@ def test_lenght_notequal_error():
     match perfectly.
     """
     heatpump = HeatPump()
-    heatpump.TinHP = [28, 3, 16]
+    heatpump.TinHP = 28
+
     with pytest.raises(ValueError):
         print(heatpump.ToutHP)
 
+    heatpump.TinHP = [28, 0]
+    heatpump.qbat = [-16.5, 14.5, 12]
+    with pytest.raises(ValueError):
+        print(heatpump.ToutHP)
+
+
+def test_single_value():
+    """
+    Test that everything is working as expected when working with
+    single values
+    """
+    heatpump = HeatPump()
+    heatpump.TinHP = 28
+    heatpump.Vf = 0.94635295
+    heatpump.qbat = -16.5
+
+    assert np.round(heatpump.ToutHP, 6) == 33.273623
+    assert np.round(heatpump.COP, 6) == 3.849727
+    assert np.round(heatpump.CAP, 6) == 20.926771
+    assert np.round(heatpump.Tm, 6) == 30.636812
+
+
+def test_public_interface_insulation():
+    pass
 
 if __name__ == "__main__":
     pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])

--- a/pygld/heatpumps/tests/test_heatpump.py
+++ b/pygld/heatpumps/tests/test_heatpump.py
@@ -13,6 +13,7 @@ import os
 # ---- Third party imports
 
 import pytest
+import numpy as np
 
 # ---- Local imports
 
@@ -29,36 +30,22 @@ def test_heatpump_init():
 
     # Assert the default values for the independent variables.
 
-    propnames = ['TinHP', 'qbat', 'Vf']
-    expected_vals = [(28, 0), (16.5, 14.5), (0.94635295, 0.94635295)]
-    for (propname, expected_val) in zip(propnames, expected_vals):
-        prop = getattr(heatpump, propname)
-        assert id(prop) == id(getattr(heatpump, propname))
-
-        assert (prop.c == prop.cooling == prop['c'] == prop['cooling'] ==
-                prop[0] == expected_val[0])
-        assert (prop.h == prop.heating == prop['h'] == prop['heating'] ==
-                prop[1] == expected_val[1])
-
+    assert np.array_equal(heatpump.TinHP, np.array([28, 0]))
+    assert np.array_equal(heatpump.qbat, np.array([-16.5, 14.5]))
+    assert np.array_equal(heatpump.Vf, np.array([0.94635295, 0.94635295]))
     assert heatpump.fluid == 'water'
     assert heatpump.fr == 0
 
     # Assert the default values for the dependent variables.
 
-    propnames = ['COP', 'CAP', 'ToutHP', 'Tm']
-    expected_vals = [(3.849727, 3.372328), (20.926771, 17.196401),
-                     (33.273623, -2.555170), (30.636812, -1.277585)]
-    for (propname, expected_val) in zip(propnames, expected_vals):
-        prop = getattr(heatpump, propname)
-        assert id(prop) == id(getattr(heatpump, propname))
-
-        assert (round(prop.c, 6) == round(prop.cooling, 6) ==
-                round(prop['c'], 6) == round(prop['cooling'], 6) ==
-                round(prop[0], 6) == expected_val[0])
-
-        assert (round(prop.h, 6) == round(prop.heating, 6) ==
-                round(prop['h'], 6) == round(prop['heating'], 6) ==
-                round(prop[1], 6) == expected_val[1])
+    assert np.array_equal(np.round(heatpump.COP, 6),
+                          np.array([3.849727, 3.372328]))
+    assert np.array_equal(np.round(heatpump.CAP, 6),
+                          np.array([20.926771, 17.196401]))
+    assert np.array_equal(np.round(heatpump.ToutHP, 6),
+                          np.array([33.273623, -2.555170]))
+    assert np.array_equal(np.round(heatpump.Tm, 6),
+                          np.array([30.636812, -1.277585]))
 
 
 def test_heatpump_need_update_flags():
@@ -79,17 +66,10 @@ def test_heatpump_need_update_flags():
     for key, value in heatpump._need_update.items():
         assert value is False
 
-    heatpump.TinHP.c = 34
+    heatpump.TinHP = 34
 
     for key, value in heatpump._need_update.items():
         assert value is True
-
-
-def test_calcul_Tm():
-    """Test that the average fluid temperature is calculated correctly."""
-    heatpump = HeatPump()
-    assert 0.5 * (heatpump.TinHP.c + heatpump.ToutHP.c) == heatpump.Tm.c
-    assert 0.5 * (heatpump.TinHP.h + heatpump.ToutHP.h) == heatpump.Tm.h
 
 
 if __name__ == "__main__":

--- a/pygld/heatpumps/tests/test_heatpump.py
+++ b/pygld/heatpumps/tests/test_heatpump.py
@@ -72,5 +72,16 @@ def test_heatpump_need_update_flags():
         assert value is True
 
 
+def test_lenght_notequal_error():
+    """
+    Test that an error is raised when TinHP, qtbat, and Vf length does not
+    match perfectly.
+    """
+    heatpump = HeatPump()
+    heatpump.TinHP = [28, 3, 16]
+    with pytest.raises(ValueError):
+        print(heatpump.ToutHP)
+
+
 if __name__ == "__main__":
     pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])

--- a/pygld/heatpumps/tests/test_heatpump.py
+++ b/pygld/heatpumps/tests/test_heatpump.py
@@ -106,7 +106,54 @@ def test_single_value():
 
 
 def test_public_interface_insulation():
-    pass
+    """
+    Test that it is not possible to modify the private variable outside of
+    the public interface.
+    """
+    heatpump = HeatPump()
+
+    # Independent variables.
+
+    TinHP = np.array([1, 2, 3, 4])
+    heatpump.TinHP = TinHP
+    assert np.array_equal(heatpump.TinHP, TinHP)
+    assert id(TinHP) != id(heatpump.TinHP)
+    assert id(TinHP) != id(heatpump._TinHP)
+    assert id(heatpump.TinHP) != id(heatpump._TinHP)
+
+    Vf = np.array([5, 4, 3, 2])
+    heatpump.Vf = Vf
+    assert np.array_equal(heatpump.Vf, Vf)
+    assert id(Vf) != id(heatpump.Vf)
+    assert id(Vf) != id(heatpump._Vf)
+    assert id(heatpump.Vf) != id(heatpump._Vf)
+
+    qbat = np.array([10, -14, 30, -32])
+    heatpump.qbat = qbat
+    assert np.array_equal(heatpump.qbat, qbat)
+    assert id(qbat) != id(heatpump.qbat)
+    assert id(qbat) != id(heatpump._qbat)
+    assert id(heatpump.qbat) != id(heatpump._qbat)
+
+    fluid = 'ethyl_glycol'
+    heatpump.fluid = fluid
+    assert heatpump.fluid == 'ethyl_glycol'
+    fluid = 'water'
+    assert heatpump.fluid == 'ethyl_glycol'
+
+    fr = 0.5
+    heatpump.fr = fr
+    assert heatpump.fr == 0.5
+    fluid = 0.25
+    assert heatpump.fr == 0.5
+
+    # Dependent variables.
+
+    assert id(heatpump.ToutHP) != id(heatpump._ToutHP)
+    assert id(heatpump.Tm) != id(heatpump._Tm)
+    assert id(heatpump.COP) != id(heatpump._COP)
+    assert id(heatpump.CAP) != id(heatpump._CAP)
+
 
 if __name__ == "__main__":
     pytest.main(['-x', os.path.basename(__file__), '-v', '-rw'])


### PR DESCRIPTION
- Remove completely the concept of `cooling` and `heating` mode
- The independent variables `TinHP`, `Vf`, and `qbat` are now all defined as numpy arrays.
- The dependent variables `COP`, `CAP`, `ToutHP`, and `Tm` all return numpy arrays.

When calculating the `COP` and `ToutHP` for every value of `TinHP`, the program uses the equations and property tables for cooling for every index where `qbat < 0` and heating where `qbat >= 0`.